### PR TITLE
Fix to get cache location extra from intent

### DIFF
--- a/wear/src/main/java/com/javadog/cgeowear/cgeoWearService.java
+++ b/wear/src/main/java/com/javadog/cgeowear/cgeoWearService.java
@@ -155,10 +155,7 @@ public class cgeoWearService extends Service
 		useWatchCompass = startIntent.getBooleanExtra(MessageDataset.KEY_WATCH_COMPASS, true);
 
 		if(useWatchCompass) {
-			Location cacheLoc = new Location("phoneApp");
-			cacheLoc.setLatitude(startIntent.getFloatExtra(MessageDataset.KEY_CACHE_LATITUDE, 0f));
-			cacheLoc.setLongitude(startIntent.getFloatExtra(MessageDataset.KEY_CACHE_LONGITUDE, 0f));
-			cacheLocation = cacheLoc;
+			cacheLocation = startIntent.getExtras().getParcelable(MessageDataset.KEY_CACHE_LOCATION);
 		}
 	}
 


### PR DESCRIPTION
Fixes bug using watch compass where cache longitude and latitude would not be set, due to the location being added as an object to the intent dataset, rather than individual floats. Tested on Sony Smartwatch 3 